### PR TITLE
Updating fstream to be read-only.

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -493,7 +493,7 @@ bool CApplication::parse_params_info(const int argc, const char** argv)
 // *******************************************************************************************
 bool CApplication::load_file_names(const string &fn, vector<string>& v_file_names)
 {
-    fstream inf(fn);
+    fstream inf(fn, ios::in);
 
     if (!inf.is_open())
     {


### PR DESCRIPTION
Before, in function `load_file_names`, an `fstream` was created to read in the provided `.txt` file. However `fstream` opens with read/write by default, which forced the input file to need write permissions. I added `ios::in` to `fstream`, which allows the input file to be read-only.