### PR TITLE
Fix missing headers when compiling with GCC 13

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 using namespace std;
 
 typedef vector<uint8_t> contig_t;


### PR DESCRIPTION
Fixes building agc with GCC 13 which currently fails because of a missing `#include <cstdint>` in `src/core/defs.h` (see "Header dependency" in https://gcc.gnu.org/gcc-13/porting_to.html for the why).