### PR TITLE
Fix wrong config length length store when using agc append to create the arc database.

### DIFF
--- a/src/core/agc_compressor.cpp
+++ b/src/core/agc_compressor.cpp
@@ -1790,8 +1790,6 @@ bool CAGCCompressor::Append(const string& _in_archive_fn, const string& _out_arc
     concatenated_genomes = _concatenated_genomes;
     adaptive_compression = _adaptive_compression;
 
-    min_match_len = compression_params.min_match_len;
-    uint32_t segment_size = compression_params.segment_size;
     verbosity = _verbosity;
 
     if (!load_file_type_info(in_archive_name))
@@ -1801,6 +1799,10 @@ bool CAGCCompressor::Append(const string& _in_archive_fn, const string& _out_arc
 
     if (!load_metadata())
         return false;
+
+    min_match_len = compression_params.min_match_len;
+    uint32_t segment_size = compression_params.segment_size;
+
     working_mode = working_mode_t::appending;
 
     out_archive = make_shared<CArchive>(false, 32 << 20);


### PR DESCRIPTION
the segment_size should be set after load_metadata() or it will be zero and is not update the original database's segment_size. This makes the stored segment_size wrong and the agc_get_ctg_len reporting wrong config size.